### PR TITLE
Add support for building for Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mit-illuminations",
-  "version": "v1.2.8-rc12",
+  "version": "1.2.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mit-illuminations",
-      "version": "v1.2.8-rc12",
+      "version": "1.2.11",
       "hasInstallScript": true,
       "dependencies": {
         "acorn": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "postinstall": "electron-builder install-app-deps",
     "build": "vue-cli-service electron:build -w",
     "make-mac-release": "vue-cli-service electron:build -m --x64 --arm64",
-    "make-windows-release": "vue-cli-service electron:build -w"
+    "make-windows-release": "vue-cli-service electron:build -w",
+    "make-linux-release": "vue-cli-service electron:build -l"
   },
   "main": "background.js",
   "dependencies": {

--- a/vue.config.js
+++ b/vue.config.js
@@ -23,7 +23,11 @@ module.exports = {
         dmg: {
           sign: false, // signing DMGs without notarizing can cause errors
           writeUpdateInfo: false // disable blockmap generation to save time
-        }
+        },
+        linux: {
+          target: ['AppImage'],
+          category: 'Development',
+        },
       },
       nodeIntegration: true,
       externals: ['serialport']


### PR DESCRIPTION
This PR adds support for building an AppImage executable for Linux systems. I can confirm that the executable can be built and run on Ubuntu 23.04.